### PR TITLE
Invoke the rust compiler for the appropriate tool chain

### DIFF
--- a/checker/src/cargo_mirai.rs
+++ b/checker/src/cargo_mirai.rs
@@ -224,10 +224,14 @@ fn call_mirai() {
 }
 
 fn call_rustc() {
-    // todo: invoke the rust compiler for the appropriate tool chain?
-    let mut cmd =
-        Command::new(std::env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc")));
-    cmd.args(std::env::args().skip(2));
+    let mut args = std::env::args_os().skip(1);
+    // The rustc to use is passed by Cargo as the first argument to RUSTC_WRAPPER
+    let mut cmd = Command::new(
+        args.next()
+            .or_else(|| std::env::var_os("RUSTC"))
+            .unwrap_or_else(|| OsString::from("rustc")),
+    );
+    cmd.args(args);
     let exit_status = cmd
         .spawn()
         .expect("could not run rustc")


### PR DESCRIPTION
## Description

When a RUSTC_WRAPPER is set, Cargo passes in its first argument a path to the right rustc executable it wants the wrapper to delegate to. See [_Environment variables Cargo reads_](https://doc.rust-lang.org/1.81.0/cargo/reference/environment-variables.html#environment-variables-cargo-reads). _"Instead of simply running rustc, Cargo will execute this specified wrapper, passing as its command-line arguments the rustc invocation, with the first argument being the path to the actual rustc."_

For example, `RUSTC_WRAPPER=/path/to/mirai cargo +nightly-2023-12-30 check` would end up running `/path/to/mirai $RUSTUP_HOME/toolchains/nightly-2023-12-30-x86_64-unknown-linux-gnu/bin/rustc --crate-name=whatever --edition=2021 src/lib.rs ...`

$RUSTC is in general _not_ set by Cargo when running a subcommand such as `cargo-mirai`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

In MIRAI: `cargo build --release`
In another crate: `PATH=$PATH:/path/to/mirai/target/release cargo +nightly-2023-12-30 mirai`