### PR TITLE
Fix generic args specialization for unevaluated MIR constants

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -2733,7 +2733,7 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
     ) -> Rc<AbstractValue> {
         let mut def_id = unevaluated.def;
         let def_ty = self.bv.cv.tcx.type_of(def_id);
-        let args = self
+        let mut args = self
             .type_visitor()
             .specialize_generic_args(unevaluated.args, &self.type_visitor().generic_argument_map);
         self.bv.cv.generic_args_cache.insert(def_id, args);
@@ -2751,7 +2751,10 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                         rustc_middle::ty::Instance::resolve(self.bv.tcx, param_env, def_id, args)
                     {
                         def_id = instance.def.def_id();
+                        args = instance.args;
                         trace!("resolved it to {:?}", def_id);
+                        trace!("resolved args {:?}", args);
+                        self.bv.cv.generic_args_cache.insert(def_id, args);
                     }
                 }
                 if self.bv.tcx.is_mir_available(def_id) {

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -916,10 +916,10 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                 }
             }
             self.reset_visitor_state();
+            *self.type_visitor_mut() = saved_type_visitor.clone();
         }
         self.def_id = saved_def_id;
         self.mir = saved_mir;
-        *self.type_visitor_mut() = saved_type_visitor;
         environment
     }
 

--- a/checker/tests/run-pass/unevaluated_mir_const_gen_arg_specialization.rs
+++ b/checker/tests/run-pass/unevaluated_mir_const_gen_arg_specialization.rs
@@ -1,0 +1,21 @@
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test that visits `BlockVisitor::visit_unevaluated_const` with a non-promoted MIR constant
+// that resolves to an instance with generic args.
+
+pub trait MyTrait {
+    const MY_ASSOC_CONST: u8;
+}
+
+pub struct MyConstGenericImpl<const N: u8>;
+
+impl<const N: u8> MyTrait for MyConstGenericImpl<N> {
+    const MY_ASSOC_CONST: u8 = N;
+}
+
+pub fn foo<T>(_x: T) {}
+
+pub fn main() {
+    foo(MyConstGenericImpl::<1>::MY_ASSOC_CONST);
+}


### PR DESCRIPTION
## Description

Currently, when visiting `BlockVisitor::visit_unevaluated_const` with a non-promoted MIR constant that resolves to an instance with generic args (e.g. a trait assoc const that resolves to a const generic - see `checker/tests/run-pass/unevaluated_mir_const_gen_arg_specialization.rs` in this PR), the [generic args of the resolved instance are NOT added to `CrateVisitor`'s `generic_args_cache` map](https://github.com/endorlabs/MIRAI/blob/b243ed73b57f43afa79887e6a7fd2acd5960129e/checker/src/block_visitor.rs#L2746-L2756). This can lead to [panics in `BlockVisitor::visit_const` for the `rustc_middle::ty::ConstKind::Param(..)` case](https://github.com/endorlabs/MIRAI/blob/b243ed73b57f43afa79887e6a7fd2acd5960129e/checker/src/block_visitor.rs#L2819-L2824) when the resolved const generic is used as an operand (see `checker/tests/run-pass/unevaluated_mir_const_gen_arg_specialization.rs` in this PR, [and also](https://rustc-dev-guide.rust-lang.org/mir/index.html#representing-constants)). This PR fixes the described issue.


Fixes # (issue)
N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
A test case `checker/tests/run-pass/unevaluated_mir_const_gen_arg_specialization.rs` that passes with this has patch applied, but fails without it with a [panic from `BlockVisitor::visit_const`](https://github.com/endorlabs/MIRAI/blob/b243ed73b57f43afa79887e6a7fd2acd5960129e/checker/src/block_visitor.rs#L2819-L2824) has been added.

## Checklist:

- [x] Fork the repo and create your branch from `main`.
- [x] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.

