### PR TITLE
Fix: inconsistent/incorrect implementations of `Ord`, `PartialOrd`, `PartialEq` and `Eq` traits leading to panics on sort

### DIFF
--- a/checker/Cargo.toml
+++ b/checker/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 build = "build.rs"
 
 [lib]
-test = false # we have no unit tests
+test = true # we have some unit tests
 doctest = false # and no doc tests
 
 [[bin]]


### PR DESCRIPTION
## Description

Since Rust >= 1.81, sort algorithms panic when they detect inconsistent/incorrect implementations of `Ord`, `PartialOrd`, `PartialEq` and `Eq` traits.

This PR: 
- Updates the `AbstractValue`, `FunctionReference`, `Path` and `PathEnum` types to ensure that their implementations of the above four traits are consistent. 
- Ensures that the `Hash` implementation (where applicable) is also consistent with `Eq` (and hence `PartialEq`) for the aforementioned types.
- Fixes panicking implementations of `Ord` for the `FunctionReference` and `PathEnum` types.

References:
<https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html#new-sort-implementations>
<https://doc.rust-lang.org/nightly/std/cmp/trait.Ord.html#how-can-i-implement-ord>
<https://github.com/rust-lang/rust/blob/1.81.0/library/core/src/slice/sort/shared/smallsort.rs#L847-L863>
<https://doc.rust-lang.org/nightly/std/hash/trait.Hash.html#hash-and-eq>

Fixes # (issue)
N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

A contrived unit test for `AbstractValue` has been added.

Panics typically happen at these [sort operations in the `summarize` function](https://github.com/endorlabs/MIRAI/blob/dd70459b8c1514055028c1c74b9fc672a3fe18e3/checker/src/summaries.rs#L242-L243).

Suggestions for how to implement more and/or better tests are welcome. 
In general, it's quite complicated (for me anyway) to create minimal tests that cause MIRAI to visit `summarize` in these inconsistent states. However, [this repo](https://github.com/mbuesch/feedreaders) from [this recent issue](https://github.com/endorlabs/MIRAI/issues/26) is also affected.

## Checklist:

- [x] Fork the repo and create your branch from `main`.
- [x] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.

